### PR TITLE
Add `*.swp` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 **/__pycache__/
 .venv
 .vscode


### PR DESCRIPTION
Vim swap files (*.swp) are not needed in version control.