### PR TITLE
license: use Apache License, Version 2.0 as is

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Reazon Holdings, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The existing LICENSE file had been modified.
This change replaces it with the unaltered, official Apache License, Version 2.0 text as published by the Apache Software Foundation.

https://www.apache.org/licenses/LICENSE-2.0.txt

Modifying the Apache License 2.0 would create a separate license and prohibit referencing "Apache" leading to potential confusion and legal uncertainty. It’s safer to keep the license text exactly as published.

https://www.apache.org/foundation/license-faq.html#mod-license