### PR TITLE
control: use Apache-2.0 license header for MDK-ARM auto-generated file

### DIFF
--- a/control/canfd_control/MDK-ARM/STM32H7.uvprojx
+++ b/control/canfd_control/MDK-ARM/STM32H7.uvprojx
@@ -1,23 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<!--
- Copyright 2025 Reazon Holdings, Inc.
- Copyright 2024 STMicroelectronics.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
- Note that STMicroelectronics and Keil Software holds copyright only for the
- auto-generated code by STM32CubeMX.
--->
 <Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="project_projx.xsd">
 
   <SchemaVersion>2.1</SchemaVersion>

--- a/control/canfd_control/MDK-ARM/STM32H7.uvprojx
+++ b/control/canfd_control/MDK-ARM/STM32H7.uvprojx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+ Copyright 2025 Reazon Holdings, Inc.
+ Copyright 2024 STMicroelectronics.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Note that STMicroelectronics and Keil Software holds copyright only for the
+ auto-generated code by STM32CubeMX.
+-->
 <Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="project_projx.xsd">
 
   <SchemaVersion>2.1</SchemaVersion>

--- a/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
+++ b/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
@@ -14,7 +14,7 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright 2024 STMicroelectronics.
+;* Copyright 2019 STMicroelectronics.
 ;*
 ;* Licensed under the Apache License, Version 2.0 (the "License");
 ;* you may not use this file except in compliance with the License.

--- a/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
+++ b/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
@@ -14,12 +14,23 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.
+;* Copyright 2025 Reazon Holdings, Inc.
+;* Copyright 2024 STMicroelectronics.
 ;*
-;* This software is licensed under terms that can be found in the LICENSE file
-;* in the root directory of this software component.
-;* If no LICENSE file comes with this software, it is provided AS-IS.
+;* Licensed under the Apache License, Version 2.0 (the "License");
+;* you may not use this file except in compliance with the License.
+;* You may obtain a copy of the License at
+;*
+;*     http://www.apache.org/licenses/LICENSE-2.0
+;*
+;* Unless required by applicable law or agreed to in writing, software
+;* distributed under the License is distributed on an "AS IS" BASIS,
+;* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;* See the License for the specific language governing permissions and
+;* limitations under the License.
+;*
+;* Note that STMicroelectronics holds copyright only for the auto-generated
+;* code by STM32CubeMX.
 ;*
 ;*******************************************************************************
 

--- a/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
+++ b/control/canfd_control/MDK-ARM/startup_stm32h723xx.s
@@ -14,7 +14,6 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright 2025 Reazon Holdings, Inc.
 ;* Copyright 2024 STMicroelectronics.
 ;*
 ;* Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,9 +27,6 @@
 ;* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;* See the License for the specific language governing permissions and
 ;* limitations under the License.
-;*
-;* Note that STMicroelectronics holds copyright only for the auto-generated
-;* code by STM32CubeMX.
 ;*
 ;*******************************************************************************
 


### PR DESCRIPTION
Use explicit Apache-2.0 license header instead of "see LICENSE".