### PR TITLE
control: use Apache-2.0 license header for auto-generated files

### DIFF
--- a/control/canfd_control/Core/Inc/stm32h7xx_hal_conf.h
+++ b/control/canfd_control/Core/Inc/stm32h7xx_hal_conf.h
@@ -7,12 +7,23 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.
+  * Copyright 2025 Reazon Holdings, Inc.
+  * Copyright 2024 STMicroelectronics.
   *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  * Note that STMicroelectronics holds copyright only for the auto-generated
+  * code by STM32CubeMX outside of any USER CODE BEGIN/END blocks.
   *
   ******************************************************************************
   */


### PR DESCRIPTION
This file is unchanged from its auto-generated version.