### PR TITLE
control: refactor and organize license for stm32h7xx_it.c

### DIFF
--- a/control/canfd_control/Core/Src/stm32h7xx_it.c
+++ b/control/canfd_control/Core/Src/stm32h7xx_it.c
@@ -6,12 +6,23 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2024 STMicroelectronics.
-  * All rights reserved.
+  * Copyright 2025 Reazon Holdings, Inc.
+  * Copyright 2024 STMicroelectronics.
   *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  * Note that STMicroelectronics holds copyright only for the auto-generated
+  * code by STM32CubeMX outside of any USER CODE BEGIN/END blocks.
   *
   ******************************************************************************
   */
@@ -22,7 +33,6 @@
 #include "stm32h7xx_it.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include "dm_drv.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -235,6 +245,7 @@ void FDCAN2_IT0_IRQHandler(void)
 void TIM2_IRQHandler(void)
 {
   /* USER CODE BEGIN TIM2_IRQn 0 */
+
   /* USER CODE END TIM2_IRQn 0 */
   HAL_TIM_IRQHandler(&htim2);
   /* USER CODE BEGIN TIM2_IRQn 1 */


### PR DESCRIPTION
Remove unnecessary code and add Apache-2.0 license.
With this fix, this file becomes identical to the auto-generated version.