### PR TITLE
control: use Apache-2.0 license header for codes written by us

### DIFF
--- a/control/canfd_control/plotter.py
+++ b/control/canfd_control/plotter.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Reazon Holdings, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import csv
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
We added Apache 2.0 license headers to codes written by us under the control directory.